### PR TITLE
Styling cleanup

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -22,6 +22,7 @@ body {
   background-size: cover, 600px;
   background-blend-mode: overlay;
   -webkit-font-smoothing: antialiased;
+  overflow: hidden;
 }
 a {
   color: #fff;

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -23,6 +23,7 @@ body {
   background-blend-mode: overlay;
   -webkit-font-smoothing: antialiased;
   overflow: hidden;
+  font-size: 1rem;
 }
 a {
   color: #fff;
@@ -35,19 +36,18 @@ a:hover {
 
 .wrapper{
   height:100%;
+  padding: 0 2rem;
 }
 
 .container{
   height: 100%;
-  width: 26rem;
-  color:#fff;
+  width: 100%;
+  color: #fff;
 }
 .container ul li {
   display: block;
 }
 .container header {
-  font-weight:bold;
-  font-size:1.1rem;
   margin-bottom: 1rem;
 }
 .container ul.team {
@@ -56,7 +56,6 @@ a:hover {
   text-align: left;
   display: block;
   position: relative;
-  font-size:1rem;
 }
 
 .bandcamp {
@@ -75,4 +74,15 @@ a:hover {
 .bandcamp a {
   display: block;
   margin-top: 1rem;
+}
+
+/* Larger screens */
+@media only screen and (min-width: 62em) {
+  .container {
+    width: 26rem;
+  }
+
+  .wrapper {
+    padding: 0 0;
+  }
 }

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="initial-scale = 1.0, maximum-scale = 1.0">
-  <title>Tundra Dawn - three nights out now</title>
+  <title>tundra dawn - three nights out now</title>
   <link href="https://fonts.googleapis.com/css?family=Work+Sans:400,500&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="./assets/css/flexboxgrid.min.css" type="text/css">
   <link rel="stylesheet" href="./assets/css/style.css" type="text/css">

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
           <h1>tundra dawn</h1>
         </header>
         <div class="row between-xs">
-          <div class="col-xs-12 col-md-5">
+          <div class="col-xs-7 col-md-5">
             <div class="row bandcamp">three nights now available on bandcamp <a href="http://music.tundradawn.co">music.tundradawn.co</a></div>
           </div>
 


### PR DESCRIPTION
- Updates the title element to be all lowercase, to match rest of branding
- Fixes issue where the page can be scrolled horizontally on mobile devices
- Adds some padding on mobile, so the text is closer to the middle of the screen.

Before / After

<img src="https://user-images.githubusercontent.com/6766444/77836195-0aaa9680-7122-11ea-88a9-1ea84e913855.PNG" width="50%" /><img src="https://user-images.githubusercontent.com/6766444/77836196-0ed6b400-7122-11ea-8f07-ea46394bea31.PNG" width="50%" />
